### PR TITLE
feat: Add Open edX background content

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,8 @@ first few days here.
 
 .. toctree::
    first-steps
+   open-edx-background
    communication
    :maxdepth: 2
    :caption: Contents:
-   
+

--- a/docs/source/open-edx-background.rst
+++ b/docs/source/open-edx-background.rst
@@ -1,0 +1,42 @@
+Open edX Background
+===================
+
+What is Open edX?
+--------------------
+Open edX refers to its two components: the Open edX Platform and the Open edX Community.
+The Open edX Platform, a scaleable web-based platform, empowers both course authors and learners.
+It consists of the Learning Management System (LMS) and the Content Management System (CMS).
+The LMS provides access to course content and supporting infrastructure to learners, course teams, and instructors.
+The CMS, also known as the Open edX Studio, empowers the authoring of custom learning experiences with the latest in instructional design.
+This open source project is supported by an international community working together to create this multiuse platform.
+The Open edX Community consists of tCRIL, the nonprofit organization that runs the project, and a number of core and individual contributors.
+For more information, see:
+
+- `What is "Open edX"? <https://open.edx.org/video/what-is-open-edx/>`_
+- `What makes the Open edX Platform unique? <https://open.edx.org/blog/what-makes-the-open-edx-platform-unique/>`_
+- `State of Open edX Community and Architecture <https://www.youtube.com/watch?v=HPrMYdwLsdE>`_
+
+More About the Open edX Community
+---------------------------------
+The Open edX community is international and includes those writing code to
+further the Open edX platform's capabilities, those authoring courses on a wide
+variety of Open edX instances, operators of those instances, instructional
+designers, translators, and more. The community is furthering the Open edX
+mission and expanding the reach and impact via numerous `working groups
+<https://openedx.atlassian.net/wiki/spaces/COMM/pages/46793351/Working+groups>`_
+and through the growing `core contributor program
+<https://openedx.atlassian.net/wiki/spaces/COMM/pages/3143205354/Open+edX+Core+Contributor+Program>`_.
+
+More About the Technical Side of the Open edX Platform
+------------------------------------------------------
+The Open edX Platform has a reasonably large codebase consisting of a monolith and a variety of microservices.
+The main platform code is hosted on GitHub `here <https://github.com/openedx/edx-platform>`_.
+The Open edX Platform is a scaleable web-based platform that empowers course authors and learners of the Learning Management System (LMS) and the Content Management System (CMS).
+There are a number of services and extensions that reside outside of the core repository, such as `Xblocks <https://edx.readthedocs.io/projects/xblock/en/latest/>`_ and
+`Micro Frontends <https://openedx.atlassian.net/wiki/spaces/FEDX/pages/2629829454/Micro+Frontend+MFE+Onboarding>`_.
+For a deeper dive, check out:
+
+- `"State of Open edX Frontend" <https://www.youtube.com/watch?v=dIzvuCwx6hg>`__
+- `"Xblocks and beyond: Extending Open edX" <https://www.youtube.com/watch?v=o2AEunjHA7g>`_
+- `"Building with Blockstore - How OpenCraft Developed LabXchange Using Open edX" <https://www.youtube.com/watch?v=DARBuFcEb8w>`_
+


### PR DESCRIPTION
New tCRIL employees should learn background information about the Open edX Platform. This module links sources for perusal.