### PR TITLE
docs: Add RTD URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # tCRIL Onboarding
-The tcril-onbarding repository contains source files for the onboarding of new employees of tCRIL. While these files are only meant to be followed by tCRIL employees, we provide them openly in case they can be of any use to members of the Open edX community. This repository is managed by tCRIL.
+The tcril-onboarding repository contains source files for the onboarding of new employees of tCRIL. While these files are only meant to be followed by tCRIL employees, we provide them openly in case they can be of any use to members of the Open edX community. This repository is managed by tCRIL.
+
+A more readable version of these files can be found on [ReadTheDocs](https://tcril-onboarding.readthedocs.io/en/latest/).


### PR DESCRIPTION
This was something that I couldn't quickly find, so adding it here for others.