### PR TITLE
fix: Update the slack invite link.

### DIFF
--- a/docs/source/communication.rst
+++ b/docs/source/communication.rst
@@ -3,7 +3,7 @@ Communication
 
 Slack
 -----
-- Check your tCRIL email for an invitation or use this `invitation link <http://openedx-slack-invite.herokuapp.com/>`_.
+- Check your tCRIL email for an invitation or use this `invitation link <http://openedx.org/slack>`_.
 - Set up an account on Open edX slack using Google SSO (with your work email).
 - Set up an account, and complete Slack’s “Getting Started” module.
 


### PR DESCRIPTION
Point to the openedx.org shortcut which we can update as needed.